### PR TITLE
add support for using PWD instead of history in wakatime

### DIFF
--- a/zsh-wakatime.plugin.zsh
+++ b/zsh-wakatime.plugin.zsh
@@ -1,12 +1,19 @@
-#wakatime for zsh
+# wakatime for zsh
 
+# hook function to send wakatime a tick
 send_wakatime_heartbeat() {
-    (wakatime --write --plugin zsh-wakatime --notfile --project Terminal --file /$(last_command)> /dev/null 2>&1 &)
+    (wakatime --write --plugin zsh-wakatime --notfile --project Terminal --file "/$(waka_filename)"> /dev/null 2>&1 &)
 }
 
-#only command without arguments to avoid senstive information
-last_command() {
-    echo $history[$[HISTCMD-1]] | cut -d ' ' -f1
+# generate text to report as "filename" to the wakatime API
+waka_filename() {
+    if [ "$WAKATIME_USE_DIRNAME" == "true" ]; then
+        # just use the current working directory
+        echo "$PWD"
+    else
+        # only command without arguments to avoid senstive information
+        echo "$history[$((HISTCMD-1))]" | cut -d ' ' -f1
+    fi
 }
 
 add-zsh-hook precmd send_wakatime_heartbeat


### PR DESCRIPTION
* add option WAKATIME_USE_DIRNAME which when "true" will cause the script to send $PWD to wakatime instead of the last command in the history
* fixed a few shellcheck warnings
* miscellaneous comment cleanup