### PR TITLE
Drop Requirement for Oh-my-zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,21 @@ Automatic time tracking for commands in ZSH using [wakatime](http://wakatime.com
 Installation (OS X only)
 ------------
 
-It depends on [zsh](http://www.zsh.org/) and [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh).
+It depends on [zsh](http://www.zsh.org/) 4.2 or higher.
 
 Also make sure you have configured wakatime via other wakatime plugins such as VIM, sublime etc.
 
 1. `pip install wakatime` . Make sure using wakatime CLI version 4.1+.
 
-2. `cd ~/.oh-my-zsh/custom/plugins && git clone git@github.com:wbinglee/zsh-wakatime.git` or whatever how you manage your zsh plugins.
+Ohmyzsh Setup
+------------
+1. `cd ~/.oh-my-zsh/custom/plugins && git clone git@github.com:wbinglee/zsh-wakatime.git` or whatever how you manage your zsh plugins.
 
-3. Edit your `.zshrc` file and add `zsh-wakatime` to oh-my-zsh plugins
+2. Edit your `.zshrc` file and add `zsh-wakatime` to oh-my-zsh plugins
+
+Antigen Setup
+------------
+1. `antigen bundle wbinglee/zsh-wakatime`
 
 4. Open a new terminal and type commands
 

--- a/zsh-wakatime.plugin.zsh
+++ b/zsh-wakatime.plugin.zsh
@@ -16,4 +16,4 @@ waka_filename() {
     fi
 }
 
-add-zsh-hook precmd send_wakatime_heartbeat
+precmd_functions+=(send_wakatime_heartbeat)


### PR DESCRIPTION
Use, the ZSH precmd_functions hook and add instructions to use antigen. 